### PR TITLE
fix(bin): update import statement for base config in temporary stencil config

### DIFF
--- a/bin/stencil-test.ts
+++ b/bin/stencil-test.ts
@@ -522,7 +522,7 @@ async function createTemporaryStencilConfig(
     // Auto-generated temporary config by stencil-test
     // This extends your stencil config and adds watchIgnoredRegex for screenshot files
 
-    import baseConfig from '${userConfigPath}';
+    import ${userConfig.config ? '{ config as baseConfig }' : 'baseConfig'} from '${userConfigPath}';
 
     export const config = {
       ...baseConfig,


### PR DESCRIPTION
Hello @johnjenkins,

It seems something got lost in the last update ;)

Is everything OK with the import now?

## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Der import der configuration ist zu fest.

Only the default export is requested; exporting to key `config` would also be important.

## What is the new behavior?

A check is performed to see whether `config` or `default` is removed from the export.

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
