### PR TITLE
fix(bin): added support for windows path

### DIFF
--- a/bin/stencil-test.ts
+++ b/bin/stencil-test.ts
@@ -520,8 +520,8 @@ async function createTemporaryStencilConfig(
 
     /**
      * Generate a simple config with user config import.
-     * 
-     * JSON.stringify for normalize path between windows and unix. 
+     *
+     * JSON.stringify for normalize path between windows and unix.
      * Windows: "C:\xxx\yyy" -> "C:\\xxx\\yyy"
      * Unix: "C:/xxx/yyy" -> "C:/xxx/yyy"
      */


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

<img width="313" height="120" alt="{CF9A61F2-CFCD-4687-AD28-113B40166AE7}" src="https://github.com/user-attachments/assets/b11c6b6b-097b-4ea7-9fdd-dc827ed33034" />

<img width="285" height="119" alt="{9A7E369C-4000-4ECA-8D30-5E182F51C13D}" src="https://github.com/user-attachments/assets/f8202191-9f24-4f89-9a0a-730fa9aa421a" />

Backslashes are used in Windows, which currently cause an error. 
And the configuration is imported as `ts` into `mjs`.

## What is the new behavior?

The path is repaired using JSON.stringify.
And normalize the configuration file extension. Based on the source configuration.

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
