### PR TITLE
fix(render): allow to spy on more than 1 event

### DIFF
--- a/src/testing/render.ts
+++ b/src/testing/render.ts
@@ -95,9 +95,13 @@ export async function render<T extends HTMLElement = HTMLElement, I = any>(
   };
 
   const spyOnEvent = (eventName: string): EventSpy => {
-    // Return existing spy if already created
-    if (eventSpies.has(container)) {
-      return eventSpies.get(container)!.find((spy) => spy.eventName === eventName)!;
+    // Return existing spy if already created for this specific event
+    const existingSpies = eventSpies.get(container);
+    if (existingSpies) {
+      const existingSpy = existingSpies.find((spy) => spy.eventName === eventName);
+      if (existingSpy) {
+        return existingSpy;
+      }
     }
 
     const spy: EventSpy = {


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [x] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

One test case cannot spy on 2 or more events

## What is the new behavior?

One test case can spy on 2 or more events

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
