### PR TITLE
fix: serialize namespaced attrs like `xlink:href`

### DIFF
--- a/src/testing/html-serializer.ts
+++ b/src/testing/html-serializer.ts
@@ -104,11 +104,19 @@ function serializeElementWithShadow(
   if (elem.attributes) {
     for (let i = 0; i < elem.attributes.length; i++) {
       const attr = elem.attributes[i];
+
+      // Handle namespaced attributes (e.g., xlink:href)
+      // Use prefix + localName if available, otherwise fall back to name
+      let attrName = attr.name;
+      if (attr.prefix && attr.localName) {
+        attrName = `${attr.prefix}:${attr.localName}`;
+      }
+
       // Boolean attributes (empty string value) should not have ="value"
       if (attr.value === '') {
-        html += ` ${attr.name}`;
+        html += ` ${attrName}`;
       } else {
-        html += ` ${attr.name}="${attr.value}"`;
+        html += ` ${attrName}="${attr.value}"`;
       }
     }
   }


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
