### PR TITLE
fix: serializer preserve svg element tagName case

### DIFF
--- a/src/testing/html-serializer.ts
+++ b/src/testing/html-serializer.ts
@@ -95,7 +95,9 @@ function serializeElementWithShadow(
   }
 
   const elem = element as HTMLElement;
-  const tagName = elem.tagName.toLowerCase();
+  // Use localName to preserve case for SVG elements (e.g., foreignObject, feGaussianBlur)
+  // For HTML elements, localName is already lowercase
+  const tagName = (elem as any).localName || elem.tagName.toLowerCase();
 
   // Build opening tag with attributes
   let html = `<${tagName}`;


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
