### PR TITLE
feat: `render()` - allow template string

### DIFF
--- a/src/testing/render.ts
+++ b/src/testing/render.ts
@@ -101,10 +101,10 @@ export async function waitForExist(selector: string, timeout = 5000): Promise<El
 }
 
 /**
- * Render using Stencil's render
+ * Render using Stencil's render or raw HTML template string
  */
 export async function render<T extends HTMLElement = HTMLElement, I = any>(
-  vnode: any,
+  template: any | string,
   options: RenderOptions = {
     clearStage: true,
     stageAttrs: { class: 'stencil-component-stage' },
@@ -122,8 +122,13 @@ export async function render<T extends HTMLElement = HTMLElement, I = any>(
   }
   document.body.appendChild(container);
 
-  // Use Stencil's render which handles VNodes properly in the browser
-  await stencilRender(vnode, container);
+  if (typeof template === 'string') {
+    // Handle string template - add as innerHTML
+    container.innerHTML = template;
+  } else {
+    // Use Stencil's render which handles VNodes properly in the browser
+    await stencilRender(template, container);
+  }
 
   // Get the rendered element
   const element = container.firstElementChild as T;


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

- `render()` now accepts a string template as test fixture

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
