### PR TITLE
fix: stop test re-runs on *.map.js file change

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,17 @@ function applyStencilDefaults(config: ViteUserConfig, stencilConfig?: StencilCon
     result.server.watch = {};
   }
 
+  // Ignore source map files to prevent unnecessary test re-runs
+  // Stencil may touch .map files without changing content, triggering Vite's watcher
+  if (!result.server.watch.ignored) {
+    result.server.watch.ignored = [];
+  }
+  const ignoredArray = Array.isArray(result.server.watch.ignored)
+    ? result.server.watch.ignored
+    : [result.server.watch.ignored];
+  const mapIgnorePatterns = ['**/*.map', '**/*.map.js'];
+  result.server.watch.ignored = [...new Set([...ignoredArray, ...mapIgnorePatterns])];
+
   // Ensure test config exists
   if (!result.test) {
     result.test = {};

--- a/src/core.ts
+++ b/src/core.ts
@@ -2,7 +2,7 @@
 import './testing/matchers.js';
 import './testing/snapshot-serializer.js';
 
-export { h, Fragment } from '@stencil/core';
+export { h } from '@stencil/core';
 export { render, waitForStable, waitForExist } from './testing/render.js';
 export { serializeHtml, prettifyHtml, SerializeOptions } from './testing/html-serializer.js';
 export type { RenderOptions, RenderResult } from './types.js';


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
