### PR TITLE
fix: pass `--no-build` to stencil, not vite

### DIFF
--- a/bin/stencil-test.ts
+++ b/bin/stencil-test.ts
@@ -55,6 +55,7 @@ interface ParsedArgs {
   verbose: boolean;
   debug: boolean;
   prod: boolean;
+  build: boolean;
 
   // Vitest flags
   project?: string[];
@@ -78,6 +79,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     verbose: false,
     debug: false,
     prod: false,
+    build: false,
     coverage: false,
     noCoverage: false,
     ui: false,
@@ -132,6 +134,43 @@ function parseArgs(argv: string[]): ParsedArgs {
 
       case '--prod':
         parsed.prod = true;
+        i++;
+        break;
+
+      case '--build':
+        parsed.build = true;
+        i++;
+        break;
+
+      // Handle --no-<flag> variants of Stencil boolean flags
+      // Stencil dynamically supports negating any boolean flag with the no- prefix
+      case '--no-watch':
+        parsed.watch = false;
+        i++;
+        break;
+
+      case '--no-serve':
+        parsed.serve = false;
+        i++;
+        break;
+
+      case '--no-verbose':
+        parsed.verbose = false;
+        i++;
+        break;
+
+      case '--no-debug':
+        parsed.debug = false;
+        i++;
+        break;
+
+      case '--no-prod':
+        parsed.prod = false;
+        i++;
+        break;
+
+      case '--no-build':
+        parsed.build = false;
         i++;
         break;
 


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
