### PR TITLE
feat: use stencil hydrated config to assess readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ await setProps({ name: 'Stencil' });
 unmount();
 ```
 
+#### `waitForReady` Option
+
+By default, `render()` waits for components to be fully hydrated before returning. It detects when Stencil applies the hydrated flag (class or attribute) to your component, respecting your `stencil.config` settings.
+
+```tsx
+// Default behaviour - waits for hydration
+const { root } = await render(<my-component />);
+
+// Skip hydration wait (useful for testing loading states)
+const { root } = await render(<my-component />, { waitForReady: false });
+```
+
 ### Available matchers:
 
 ```typescript

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import {
   getStencilSrcDir,
   getStencilOutputDirs,
   getStencilResolveAliases,
+  getStencilHydratedFlag,
 } from './setup/config-loader.js';
 import type { Config as StencilConfig } from '@stencil/core/internal';
 
@@ -149,6 +150,7 @@ function applyStencilDefaults(config: ViteUserConfig, stencilConfig?: StencilCon
     __STENCIL_PROD__: JSON.stringify(process.env.STENCIL_PROD === 'true'),
     __STENCIL_SERVE__: JSON.stringify(process.env.STENCIL_SERVE === 'true'),
     __STENCIL_PORT__: JSON.stringify(process.env.STENCIL_PORT || ''),
+    __STENCIL_HYDRATED_FLAG__: JSON.stringify(getStencilHydratedFlag(stencilConfig)),
   };
 
   if (!result.define) {
@@ -382,6 +384,7 @@ function enhanceProject(project: any, stencilConfig?: StencilConfig): any {
     __STENCIL_PROD__: JSON.stringify(process.env.STENCIL_PROD === 'true'),
     __STENCIL_SERVE__: JSON.stringify(process.env.STENCIL_SERVE === 'true'),
     __STENCIL_PORT__: JSON.stringify(process.env.STENCIL_PORT || ''),
+    __STENCIL_HYDRATED_FLAG__: JSON.stringify(getStencilHydratedFlag(stencilConfig)),
   };
 
   if (!enhanced.define) {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -21,3 +21,13 @@
 declare const __STENCIL_PROD__: boolean;
 declare const __STENCIL_SERVE__: boolean;
 declare const __STENCIL_PORT__: string;
+
+interface StencilHydratedFlag {
+  name: string;
+  selector: 'class' | 'attribute';
+  property: string;
+  initialValue: string;
+  hydratedValue: string;
+}
+
+declare const __STENCIL_HYDRATED_FLAG__: StencilHydratedFlag | null;

--- a/src/setup/config-loader.ts
+++ b/src/setup/config-loader.ts
@@ -1,4 +1,4 @@
-import type { Config as StencilConfig } from '@stencil/core/internal';
+import type { Config as StencilConfig, HydratedFlag } from '@stencil/core/internal';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 
@@ -81,6 +81,27 @@ export function getStencilOutputDirs(config?: StencilConfig): string[] {
   const validDirs = Array.from(outputDirs).filter((dir) => !dir.includes('..'));
 
   return validDirs.length > 0 ? validDirs : ['dist', 'www', 'build', '.stencil'];
+}
+
+/**
+ * Get the hydrated flag configuration from Stencil config.
+ * Returns null if hydration indication is explicitly disabled.
+ * Returns defaults if not configured.
+ */
+export function getStencilHydratedFlag(config?: StencilConfig): HydratedFlag | null {
+  // If explicitly null, hydration indication is disabled
+  if (config?.hydratedFlag === null) {
+    return null;
+  }
+  // If undefined or object, return with defaults applied
+  const flag = config?.hydratedFlag;
+  return {
+    name: flag?.name ?? 'hydrated',
+    selector: flag?.selector ?? 'class',
+    property: flag?.property ?? 'visibility',
+    initialValue: flag?.initialValue ?? 'hidden',
+    hydratedValue: flag?.hydratedValue ?? 'inherit',
+  };
 }
 
 /**

--- a/src/testing/render.ts
+++ b/src/testing/render.ts
@@ -47,6 +47,76 @@ function isRealBrowser(): boolean {
 }
 
 /**
+ * Get the hydrated flag config, with defaults when not configured.
+ * Returns null if hydration is explicitly disabled.
+ */
+function getHydratedFlag(): { name: string; selector: 'class' | 'attribute' } | null {
+  // If global is defined, use it (could be null if explicitly disabled)
+  if (typeof __STENCIL_HYDRATED_FLAG__ !== 'undefined') {
+    return __STENCIL_HYDRATED_FLAG__;
+  }
+  // Default to 'hydrated' class when no config loaded
+  return { name: 'hydrated', selector: 'class' };
+}
+
+/**
+ * Find the first custom element (tag contains '-') in the tree.
+ * If the element itself is a custom element, returns it.
+ * Otherwise walks down to find the topmost custom element child.
+ */
+function findCustomElement(element: Element): Element | null {
+  if (element.tagName.includes('-')) {
+    return element;
+  }
+  // Breadth-first search for first custom element
+  const queue: Element[] = Array.from(element.children);
+  while (queue.length > 0) {
+    const child = queue.shift()!;
+    if (child.tagName.includes('-')) {
+      return child;
+    }
+    queue.push(...Array.from(child.children));
+  }
+  return null;
+}
+
+/**
+ * Wait for element to be hydrated based on Stencil's hydrated flag config.
+ * Checks for the hydrated class or attribute as configured.
+ * Returns immediately if hydration is disabled (flag is null).
+ */
+async function waitForHydrated(element: Element, timeout = 5000): Promise<void> {
+  const flag = getHydratedFlag();
+
+  // If hydration is disabled, skip this check
+  if (flag === null) {
+    return;
+  }
+
+  // Find the custom element to check - hydrated flag is applied to the component, not wrappers
+  const customElement = findCustomElement(element);
+  if (!customElement) {
+    return;
+  }
+
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    const isHydrated =
+      flag.selector === 'attribute'
+        ? customElement.hasAttribute(flag.name)
+        : customElement.classList.contains(flag.name);
+
+    if (isHydrated) {
+      return;
+    }
+
+    await new Promise((r) => requestAnimationFrame(r));
+  }
+  // Don't throw - component might not use hydration or might be ready without flag
+}
+
+/**
  * Poll until element has dimensions (is rendered/visible in real browser).
  * Accepts either an Element or a CSS selector string.
  * If a selector is provided, waits for the element to appear in the DOM first.
@@ -205,10 +275,9 @@ export async function render<T extends HTMLElement = HTMLElement, I = any>(
 
   // Wait for component to be fully rendered if requested (default: true)
   if (options.waitForReady !== false) {
-    if (isRealBrowser()) {
-      // In real browser, poll until element has dimensions
-      await waitForStable(element);
-    }
+    // Wait for Stencil's hydration flag (skipped if hydration disabled)
+    await waitForHydrated(element);
+
     // Always wait for Stencil's update cycle to complete
     await waitForChanges();
   }


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [x] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

Use stencil's `hydrated` config to assess component readiness instead of element visibility (which only worked in the browser).

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
