### PR TITLE
fix: `waitForReady` skips `whenDefined` and `componentOnReady` checks

### DIFF
--- a/src/testing/render.ts
+++ b/src/testing/render.ts
@@ -277,7 +277,7 @@ export async function render<T extends HTMLElement = HTMLElement, I = any>(
     await waitForChanges();
   }
 
-   // Clear per-render spy config after component is ready
+  // Clear per-render spy config after component is ready
   if (options.spyOn) {
     setRenderSpyConfig(null);
   }


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
