### PR TITLE
feat: vite plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,83 @@ expect(clickSpy.firstEvent?.detail).toEqual({ buttonId: 'my-button' });
 expect(clickSpy.lastEvent?.detail).toEqual({ buttonId: 'my-button' });
 ```
 
+## Stencil Vitest Plugin
+
+The default testing approach in this package works against **pre-built dist outputs** — Stencil compiles your components once and tests run against those bundles. This is fast and reliable, but it means Vitest never sees individual component source files as discrete modules. As a result, `vi.mock()` cannot intercept imports made by your components, because the dependency is already bundled away before Vitest gets involved.
+
+`stencilVitestPlugin` solves this by hooking into Vite's transform pipeline. Every `.tsx` file containing Stencil decorators is compiled on-the-fly via `transpileSync` before Vitest imports it, using `componentExport: 'customelement'`. This means each component file becomes its own entry in Vitest's module graph — and its imports are independently resolvable and mockable.
+
+### Setup
+
+```typescript
+// vitest.config.ts
+import { defineVitestConfig } from '@stencil/vitest/config';
+import { stencilVitestPlugin } from '@stencil/vitest/plugin';
+
+export default defineVitestConfig({
+  stencilConfig: './stencil.config.ts',
+  test: {
+    projects: [
+      {
+        plugins: [stencilVitestPlugin()],
+        test: {
+          name: 'plugin',
+          environment: 'stencil',
+          include: ['src/**/*.plugin.spec.{ts,tsx}'],
+          // No dist setup file needed — each component source file registers
+          // itself via customElements.define() the moment it is imported.
+        },
+      },
+    ],
+  },
+});
+```
+
+### Mocking component dependencies
+
+With the plugin active, import the component source directly in your test. The plugin compiles it on-the-fly and the `customElements.define()` call at the end of the transformed output registers the element immediately.
+
+```tsx
+// my-label.plugin.spec.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@stencil/vitest';
+import { h } from '@stencil/core';
+
+// vi.mock() is hoisted — the mock is in place before any imports resolve
+vi.mock('../utils/index.js', () => ({
+  capitalize: vi.fn((s: string) => `[mocked:${s}]`),
+}));
+
+// Importing the source file triggers the on-the-fly compile + define
+import './my-label.tsx';
+import { capitalize } from '../utils/index.js';
+
+it('renders using the mocked utility', async () => {
+  vi.mocked(capitalize).mockReturnValue('Intercepted');
+
+  const { root } = await render(<my-label value="hello" />);
+
+  expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('Intercepted');
+  expect(capitalize).toHaveBeenCalledWith('hello');
+});
+```
+
+### Limitations
+
+#### Class inheritance
+
+In Stencil v4 `transpileSync` (used within the plugin) is a single-file compiler. When a component class `extends` a base class that lives in a separate file, `transpileSync` cannot follow the import to merge the parent's metadata and will throw an error.
+
+```tsx
+// ❌ Will fail — base class is in a separate file
+import { FormBase } from './form-base.js';
+
+@Component({ tag: 'my-input', shadow: true })
+export class MyInput extends FormBase { ... }
+```
+
+> This limitation is specific to v4. Stencil v5's compiler can resolve multi-file inheritance chains.
+
 ## Snapshots
 
 The package includes a custom snapshot serializer for Stencil components that properly handles shadow DOM:

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ expect(clickSpy.lastEvent?.detail).toEqual({ buttonId: 'my-button' });
 
 ## Stencil Vitest Plugin
 
-The default testing approach in this package works against **pre-built dist outputs** — Stencil compiles your components once and tests run against those bundles. This is fast and reliable, but it means Vitest never sees individual component source files as discrete modules. As a result, `vi.mock()` cannot intercept imports made by your components, because the dependency is already bundled away before Vitest gets involved.
+The recommended testing approach in this package is to test against **pre-built dist outputs** — Stencil compiles your components once and tests run against those bundles. This is fast and reliable, but it does mean Vitest never sees individual component source files as discrete modules. As a result, `vi.mock()` cannot intercept imports made by your components, because the dependency is already bundled away before Vitest gets involved.
 
 `stencilVitestPlugin` solves this by hooking into Vite's transform pipeline. Every `.tsx` file containing Stencil decorators is compiled on-the-fly via `transpileSync` before Vitest imports it, using `componentExport: 'customelement'`. This means each component file becomes its own entry in Vitest's module graph — and its imports are independently resolvable and mockable.
 

--- a/README.md
+++ b/README.md
@@ -479,8 +479,7 @@ With the plugin active, import the component source directly in your test. The p
 ```tsx
 // my-label.plugin.spec.tsx
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@stencil/vitest';
-import { h } from '@stencil/core';
+import { render, h } from '@stencil/vitest';
 
 // vi.mock() is hoisted — the mock is in place before any imports resolve
 vi.mock('../utils/index.js', () => ({

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/setup/happy-dom-setup.d.ts",
       "import": "./dist/setup/happy-dom-setup.js"
     },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js"
+    },
     "./vitest": {
       "types": "./dist/environments/stencil.d.ts",
       "import": "./dist/environments/stencil.js"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,92 @@
+import type { Plugin } from 'vitest/config';
+
+/**
+ * A Vite/Vitest plugin that transforms Stencil component source files (.tsx) on-the-fly,
+ * enabling module mocking and direct source imports during tests.
+ *
+ * The compiled output uses `componentExport: 'customelement'`, which appends a
+ * `customElements.define()` call at the end of the transformed file. The component
+ * registers itself the moment the module is imported — no dist loader or setup file
+ * required. Works with `@stencil/core` v4 and v5.
+ *
+ * @example
+ * ```ts
+ * // vitest.config.ts
+ * import { defineVitestConfig } from '@stencil/vitest/config';
+ * import { stencilVitestPlugin } from '@stencil/vitest/plugin';
+ *
+ * export default defineVitestConfig({
+ *   plugins: [stencilVitestPlugin()],
+ *   test: {
+ *     projects: [
+ *       {
+ *         test: {
+ *           name: 'stencil',
+ *           environment: 'stencil',
+ *           include: ['**\/*.spec.tsx'],
+ *           // No dist loader needed — import components from source directly
+ *         },
+ *       },
+ *     ],
+ *   },
+ * });
+ * ```
+ *
+ * @returns a Vite plugin configuration object
+ */
+export function stencilVitestPlugin(): Plugin {
+  return {
+    name: 'stencil-vitest-transform',
+    enforce: 'pre',
+
+    async transform(code, id) {
+      // Only transform .tsx files
+      if (!id.endsWith('.tsx')) {
+        return null;
+      }
+
+      // Quick check for Stencil decorator patterns before paying the compiler cost
+      const hasStencilDecorator =
+        code.includes('@Component') ||
+        code.includes('@Prop') ||
+        code.includes('@State') ||
+        code.includes('@Event') ||
+        code.includes('@Method') ||
+        code.includes('@Watch') ||
+        code.includes('@Listen');
+
+      if (!hasStencilDecorator) {
+        return null;
+      }
+
+      const { transpileSync } = await import('@stencil/core/compiler');
+
+      const result = transpileSync(code, {
+        file: id,
+        // 'customelement' appends a customElements.define() call so the component
+        // self-registers the moment this module is imported — no loader needed.
+        componentExport: 'customelement',
+        componentMetadata: 'compilerstatic',
+        currentDirectory: process.cwd(),
+        module: 'esm',
+        proxy: null,
+        sourceMap: false,
+        style: 'static',
+        styleImportData: 'queryparams',
+        target: 'es2022',
+        // Don't rewrite import paths — let Vite handle resolution via aliases
+        transformAliasedImportPaths: false,
+      });
+
+      const errors = result.diagnostics?.filter((d) => d.level === 'error') ?? [];
+      if (errors.length > 0) {
+        const messages = errors.map((d) => d.messageText).join('\n');
+        throw new Error(`[stencil-vitest-plugin] Transform error in ${id}:\n${messages}`);
+      }
+
+      return {
+        code: result.code,
+      };
+    },
+  };
+}

--- a/test-project/src/components.d.ts
+++ b/test-project/src/components.d.ts
@@ -56,6 +56,17 @@ export namespace Components {
         "interactive": boolean;
     }
     /**
+     * A label component that formats its value using the capitalize utility.
+     * Used to demonstrate vi.mock() working with the stencilVitestPlugin.
+     */
+    interface MyLabel {
+        /**
+          * Raw text to display — run through `capitalize()` before rendering
+          * @default ''
+         */
+        "value": string;
+    }
+    /**
      * Test component with scoped encapsulation (non-shadow) and slots
      * Stencil polyfills slot behavior and protects the component by monkey-patching
      * childNodes, children, firstChild, lastChild to only return lightDOM
@@ -109,6 +120,16 @@ declare global {
         new (): HTMLMyCardElement;
     };
     /**
+     * A label component that formats its value using the capitalize utility.
+     * Used to demonstrate vi.mock() working with the stencilVitestPlugin.
+     */
+    interface HTMLMyLabelElement extends Components.MyLabel, HTMLStencilElement {
+    }
+    var HTMLMyLabelElement: {
+        prototype: HTMLMyLabelElement;
+        new (): HTMLMyLabelElement;
+    };
+    /**
      * Test component with scoped encapsulation (non-shadow) and slots
      * Stencil polyfills slot behavior and protects the component by monkey-patching
      * childNodes, children, firstChild, lastChild to only return lightDOM
@@ -124,6 +145,7 @@ declare global {
         "lifecycle-throw": HTMLLifecycleThrowElement;
         "my-button": HTMLMyButtonElement;
         "my-card": HTMLMyCardElement;
+        "my-label": HTMLMyLabelElement;
         "non-shadow-component": HTMLNonShadowComponentElement;
     }
 }
@@ -182,6 +204,17 @@ declare namespace LocalJSX {
         "interactive"?: boolean;
     }
     /**
+     * A label component that formats its value using the capitalize utility.
+     * Used to demonstrate vi.mock() working with the stencilVitestPlugin.
+     */
+    interface MyLabel {
+        /**
+          * Raw text to display — run through `capitalize()` before rendering
+          * @default ''
+         */
+        "value"?: string;
+    }
+    /**
      * Test component with scoped encapsulation (non-shadow) and slots
      * Stencil polyfills slot behavior and protects the component by monkey-patching
      * childNodes, children, firstChild, lastChild to only return lightDOM
@@ -203,11 +236,15 @@ declare namespace LocalJSX {
         "elevation": 0 | 1 | 2 | 3;
         "interactive": boolean;
     }
+    interface MyLabelAttributes {
+        "value": string;
+    }
 
     interface IntrinsicElements {
         "lifecycle-throw": Omit<LifecycleThrow, keyof LifecycleThrowAttributes> & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes]?: LifecycleThrow[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `attr:${K}`]?: LifecycleThrowAttributes[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `prop:${K}`]?: LifecycleThrow[K] };
         "my-button": Omit<MyButton, keyof MyButtonAttributes> & { [K in keyof MyButton & keyof MyButtonAttributes]?: MyButton[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `attr:${K}`]?: MyButtonAttributes[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `prop:${K}`]?: MyButton[K] };
         "my-card": Omit<MyCard, keyof MyCardAttributes> & { [K in keyof MyCard & keyof MyCardAttributes]?: MyCard[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `attr:${K}`]?: MyCardAttributes[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `prop:${K}`]?: MyCard[K] };
+        "my-label": Omit<MyLabel, keyof MyLabelAttributes> & { [K in keyof MyLabel & keyof MyLabelAttributes]?: MyLabel[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `attr:${K}`]?: MyLabelAttributes[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `prop:${K}`]?: MyLabel[K] };
         "non-shadow-component": NonShadowComponent;
     }
 }
@@ -228,6 +265,11 @@ declare module "@stencil/core" {
              * A card component with header, content, and footer slots
              */
             "my-card": LocalJSX.IntrinsicElements["my-card"] & JSXBase.HTMLAttributes<HTMLMyCardElement>;
+            /**
+             * A label component that formats its value using the capitalize utility.
+             * Used to demonstrate vi.mock() working with the stencilVitestPlugin.
+             */
+            "my-label": LocalJSX.IntrinsicElements["my-label"] & JSXBase.HTMLAttributes<HTMLMyLabelElement>;
             /**
              * Test component with scoped encapsulation (non-shadow) and slots
              * Stencil polyfills slot behavior and protects the component by monkey-patching

--- a/test-project/src/components/my-badge/my-badge.tsx
+++ b/test-project/src/components/my-badge/my-badge.tsx
@@ -1,0 +1,32 @@
+import { Component, Prop, h } from '@stencil/core';
+import { capitalize } from '../../utils/index.js';
+
+/**
+ * Base class providing shared formatting logic.
+ * Must be co-located in the same file as the component when using
+ * stencilVitestPlugin, because transpileSync is a single-file compiler
+ * and cannot follow imports to resolve external base class metadata.
+ */
+class FormattedBase {
+  /** Applies capitalize() from utils — mockable in tests */
+  protected format(value: string): string {
+    return capitalize(value);
+  }
+}
+
+/**
+ * A labelled badge that extends FormattedBase for its text formatting.
+ * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+ */
+@Component({
+  tag: 'my-badge',
+  shadow: true,
+})
+export class MyBadge extends FormattedBase {
+  /** The badge label — passed through this.format() before rendering */
+  @Prop() label: string = '';
+
+  render() {
+    return <span class="badge">{this.format(this.label)}</span>;
+  }
+}

--- a/test-project/src/components/my-label/my-label.plugin.spec.tsx
+++ b/test-project/src/components/my-label/my-label.plugin.spec.tsx
@@ -1,0 +1,64 @@
+/**
+ * Demonstrates module mocking with stencilVitestPlugin.
+ *
+ * The plugin transforms my-label.tsx on-the-fly via the Stencil compiler
+ * (componentExport: 'customelement'), so it enters Vitest's module graph as
+ * a discrete ES module. That means vi.mock() can intercept any import the
+ * component makes — here we mock the capitalize() utility it calls in render().
+ *
+ * This is impossible with the pre-built dist approach because the component
+ * and its dependencies are already bundled together before Vitest sees them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@stencil/vitest';
+import { h } from '@stencil/core';
+
+// vi.mock() is hoisted to the top of the file by Vitest.
+// The path resolves to the same absolute module my-label.tsx imports.
+vi.mock('../../utils/index.js', () => ({
+  capitalize: vi.fn((s: string) => `[mocked:${s}]`),
+}));
+
+// Import the component source — the plugin transforms it on-the-fly
+// and the resulting customElements.define() call registers <my-label>
+// the moment this import resolves.
+import './my-label.tsx';
+import { capitalize } from '../../utils/index.js';
+
+describe('my-label — module mocking via stencilVitestPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders using the real capitalize by default (sanity check)', async () => {
+    // Temporarily restore the real implementation for this one test
+    vi.mocked(capitalize).mockImplementation((s) => s.charAt(0).toUpperCase() + s.slice(1));
+
+    const { root } = await render(<my-label value="hello" />);
+    const span = root.shadowRoot!.querySelector('span');
+    expect(span?.textContent).toBe('Hello');
+  });
+
+  it('renders using the mocked capitalize', async () => {
+    vi.mocked(capitalize).mockReturnValue('[mocked:hello]');
+
+    const { root } = await render(<my-label value="hello" />);
+    const span = root.shadowRoot!.querySelector('span');
+
+    expect(span?.textContent).toBe('[mocked:hello]');
+    expect(capitalize).toHaveBeenCalledWith('hello');
+  });
+
+  it('reflects prop changes through the mock', async () => {
+    vi.mocked(capitalize).mockImplementation((s) => `UPPER:${s.toUpperCase()}`);
+
+    const { root, setProps, waitForChanges } = await render(<my-label value="world" />);
+    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:WORLD');
+
+    await setProps({ value: 'changed' });
+    await waitForChanges();
+
+    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:CHANGED');
+    expect(capitalize).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test-project/src/components/my-label/my-label.tsx
+++ b/test-project/src/components/my-label/my-label.tsx
@@ -1,0 +1,19 @@
+import { Component, Prop, h } from '@stencil/core';
+import { capitalize } from '../../utils/index.js';
+
+/**
+ * A label component that formats its value using the capitalize utility.
+ * Used to demonstrate vi.mock() working with the stencilVitestPlugin.
+ */
+@Component({
+  tag: 'my-label',
+  shadow: true,
+})
+export class MyLabel {
+  /** Raw text to display — run through `capitalize()` before rendering */
+  @Prop() value: string = '';
+
+  render() {
+    return <span class="label">{capitalize(this.value)}</span>;
+  }
+}

--- a/test-project/vitest.config.ts
+++ b/test-project/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineVitestConfig } from '@stencil/vitest/config';
+import { stencilVitestPlugin } from '@stencil/vitest/plugin';
 import { playwright } from '@vitest/browser-playwright';
 import path from 'node:path';
 
@@ -16,8 +17,19 @@ export default defineVitestConfig({
             '**/*-jsdom.spec.{ts,tsx}',
             '**/*-happy.spec.{ts,tsx}',
             '**/*.happy.spec.{ts,tsx}',
+            '**/*.plugin.spec.{ts,tsx}',
           ],
           setupFiles: ['./vitest-setup-dist.ts'],
+        },
+      },
+      {
+        plugins: [stencilVitestPlugin()],
+        test: {
+          name: 'plugin',
+          environment: 'stencil',
+          include: ['**/*.plugin.spec.{ts,tsx}'],
+          // No dist setup file — the plugin's customElements.define() output
+          // registers each component the moment its source file is imported.
         },
       },
       {


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [x] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

## Stencil Vitest Plugin

The recommended testing approach in this package is to test against **pre-built dist outputs** — Stencil compiles your components once and tests run against those bundles. This is fast and reliable, but it does mean Vitest never sees individual component source files as discrete modules. As a result, `vi.mock()` cannot intercept imports made by your components, because the dependency is already bundled away before Vitest gets involved.

`stencilVitestPlugin` solves this by hooking into Vite's transform pipeline. Every `.tsx` file containing Stencil decorators is compiled on-the-fly via `transpileSync` before Vitest imports it, using `componentExport: 'customelement'`. This means each component file becomes its own entry in Vitest's module graph — and its imports are independently resolvable and mockable.

### Setup

```typescript
// vitest.config.ts
import { defineVitestConfig } from '@stencil/vitest/config';
import { stencilVitestPlugin } from '@stencil/vitest/plugin';

export default defineVitestConfig({
  stencilConfig: './stencil.config.ts',
  test: {
    projects: [
      {
        plugins: [stencilVitestPlugin()],
        test: {
          name: 'plugin',
          environment: 'stencil',
          include: ['src/**/*.plugin.spec.{ts,tsx}'],
          // No dist setup file needed — each component source file registers
          // itself via customElements.define() the moment it is imported.
        },
      },
    ],
  },
});
```

### Mocking component dependencies

With the plugin active, import the component source directly in your test. The plugin compiles it on-the-fly and the `customElements.define()` call at the end of the transformed output registers the element immediately.

```tsx
// my-label.plugin.spec.tsx
import { describe, it, expect, vi } from 'vitest';
import { render, h } from '@stencil/vitest';

// vi.mock() is hoisted — the mock is in place before any imports resolve
vi.mock('../utils/index.js', () => ({
  capitalize: vi.fn((s: string) => `[mocked:${s}]`),
}));

// Importing the source file triggers the on-the-fly compile + define
import './my-label.tsx';
import { capitalize } from '../utils/index.js';

it('renders using the mocked utility', async () => {
  vi.mocked(capitalize).mockReturnValue('Intercepted');

  const { root } = await render(<my-label value="hello" />);

  expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('Intercepted');
  expect(capitalize).toHaveBeenCalledWith('hello');
});
```

### Limitations

#### Class inheritance

In Stencil v4 `transpileSync` (used within the plugin) is a single-file compiler. When a component class `extends` a base class that lives in a separate file, `transpileSync` cannot follow the import to merge the parent's metadata and will throw an error.

```tsx
// ❌ Will fail — base class is in a separate file
import { FormBase } from './form-base.js';

@Component({ tag: 'my-input', shadow: true })
export class MyInput extends FormBase { ... }
```

> This limitation is specific to v4. Stencil v5's compiler can resolve multi-file inheritance chains.


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
