### PR TITLE
fix: sort html attributes

### DIFF
--- a/src/testing/html-serializer.ts
+++ b/src/testing/html-serializer.ts
@@ -102,11 +102,15 @@ function serializeElementWithShadow(
   // Build opening tag with attributes
   let html = `<${tagName}`;
 
-  // Add attributes
+  // Add attributes sorted alphabetically for deterministic output across dev/prod builds
   if (elem.attributes) {
-    for (let i = 0; i < elem.attributes.length; i++) {
-      const attr = elem.attributes[i];
+    const attrs = Array.from(elem.attributes).sort((a, b) => {
+      const nameA = a.prefix && a.localName ? `${a.prefix}:${a.localName}` : a.name;
+      const nameB = b.prefix && b.localName ? `${b.prefix}:${b.localName}` : b.name;
+      return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+    });
 
+    for (const attr of attrs) {
       // Handle namespaced attributes (e.g., xlink:href)
       // Use prefix + localName if available, otherwise fall back to name
       let attrName = attr.name;
@@ -258,6 +262,40 @@ export function prettifyHtml(html: string): string {
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Sort attributes alphabetically within every opening HTML tag in a string.
+ * Used to normalise expected HTML strings before comparison so that attribute
+ * order written by hand in tests does not have to match the order produced by
+ * the runtime (which can differ between dev and prod Stencil builds).
+ *
+ * Handles double-quoted attribute values and bare boolean attributes.
+ * Does NOT touch closing tags, self-closing tags, or text content.
+ */
+export function sortAttributesInHtml(html: string): string {
+  // Match opening tags: capture tag name and the rest of the attribute string
+  return html.replace(/<([a-zA-Z][a-zA-Z0-9:._-]*)((?:\s[^>]*)?)>/g, (_match, tagName: string, attrStr: string) => {
+    if (!attrStr.trim()) {
+      return `<${tagName}>`;
+    }
+
+    // Parse individual attributes (boolean attrs and attr="value" attrs)
+    const attrPattern = /\s+([^\s=>"/]+)(?:="([^"]*?)")?/g;
+    const attrs: Array<{ name: string; value: string | null }> = [];
+    let m: RegExpExecArray | null;
+    while ((m = attrPattern.exec(attrStr)) !== null) {
+      attrs.push({ name: m[1], value: m[2] !== undefined ? m[2] : null });
+    }
+
+    attrs.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    const sortedAttrStr = attrs
+      .map(({ name, value }) => (value === null ? ` ${name}` : ` ${name}="${value}"`))
+      .join('');
+
+    return `<${tagName}${sortedAttrStr}>`;
+  });
 }
 
 /**

--- a/src/testing/matchers.ts
+++ b/src/testing/matchers.ts
@@ -5,7 +5,7 @@
  */
 
 import { expect } from 'vitest';
-import { serializeHtml, normalizeHtml, prettifyHtml } from './html-serializer.js';
+import { serializeHtml, normalizeHtml, prettifyHtml, sortAttributesInHtml } from './html-serializer.js';
 import type { EventSpy } from '../types.js';
 
 /**
@@ -441,8 +441,9 @@ function toEqualHtml(
     const expectedFragment = parseHtmlFragment(expected.trim());
     expectedHtml = serializeHtml(expectedFragment, { serializeShadowRoot: true, pretty: false });
   } else {
-    // For element comparisons, just normalize to preserve <mock:shadow-root> tags
-    expectedHtml = expected.trim();
+    // For element comparisons, sort attributes so hand-written expected HTML is
+    // order-independent (dev vs prod builds can reflect props in different orders)
+    expectedHtml = sortAttributesInHtml(expected.trim());
   }
 
   expectedHtml = normalizeHtml(expectedHtml);
@@ -500,8 +501,9 @@ function toEqualLightHtml(
     const expectedFragment = parseHtmlFragment(expected.trim());
     expectedHtml = serializeHtml(expectedFragment, { serializeShadowRoot: false, pretty: false });
   } else {
-    // For element comparisons, just normalize to preserve <mock:shadow-root> tags
-    expectedHtml = expected.trim();
+    // For element comparisons, sort attributes so hand-written expected HTML is
+    // order-independent (dev vs prod builds can reflect props in different orders)
+    expectedHtml = sortAttributesInHtml(expected.trim());
   }
 
   expectedHtml = normalizeHtml(expectedHtml);

--- a/test-project/src/components.d.ts
+++ b/test-project/src/components.d.ts
@@ -17,6 +17,17 @@ export namespace Components {
         "label": string;
     }
     /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface MyBadge {
+        /**
+          * The badge label — passed through this.format() before rendering
+          * @default ''
+         */
+        "label": string;
+    }
+    /**
      * A simple button component for testing
      */
     interface MyButton {
@@ -90,6 +101,16 @@ declare global {
         prototype: HTMLLifecycleThrowElement;
         new (): HTMLLifecycleThrowElement;
     };
+    /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface HTMLMyBadgeElement extends Components.MyBadge, HTMLStencilElement {
+    }
+    var HTMLMyBadgeElement: {
+        prototype: HTMLMyBadgeElement;
+        new (): HTMLMyBadgeElement;
+    };
     interface HTMLMyButtonElementEventMap {
         "buttonClick": MouseEvent;
     }
@@ -143,6 +164,7 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "lifecycle-throw": HTMLLifecycleThrowElement;
+        "my-badge": HTMLMyBadgeElement;
         "my-button": HTMLMyButtonElement;
         "my-card": HTMLMyCardElement;
         "my-label": HTMLMyLabelElement;
@@ -157,6 +179,17 @@ declare namespace LocalJSX {
     interface LifecycleThrow {
         /**
           * Required label prop - throws if not provided
+         */
+        "label"?: string;
+    }
+    /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface MyBadge {
+        /**
+          * The badge label — passed through this.format() before rendering
+          * @default ''
          */
         "label"?: string;
     }
@@ -226,6 +259,9 @@ declare namespace LocalJSX {
     interface LifecycleThrowAttributes {
         "label": string;
     }
+    interface MyBadgeAttributes {
+        "label": string;
+    }
     interface MyButtonAttributes {
         "variant": 'primary' | 'secondary' | 'danger';
         "disabled": boolean;
@@ -242,6 +278,7 @@ declare namespace LocalJSX {
 
     interface IntrinsicElements {
         "lifecycle-throw": Omit<LifecycleThrow, keyof LifecycleThrowAttributes> & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes]?: LifecycleThrow[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `attr:${K}`]?: LifecycleThrowAttributes[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `prop:${K}`]?: LifecycleThrow[K] };
+        "my-badge": Omit<MyBadge, keyof MyBadgeAttributes> & { [K in keyof MyBadge & keyof MyBadgeAttributes]?: MyBadge[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `attr:${K}`]?: MyBadgeAttributes[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `prop:${K}`]?: MyBadge[K] };
         "my-button": Omit<MyButton, keyof MyButtonAttributes> & { [K in keyof MyButton & keyof MyButtonAttributes]?: MyButton[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `attr:${K}`]?: MyButtonAttributes[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `prop:${K}`]?: MyButton[K] };
         "my-card": Omit<MyCard, keyof MyCardAttributes> & { [K in keyof MyCard & keyof MyCardAttributes]?: MyCard[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `attr:${K}`]?: MyCardAttributes[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `prop:${K}`]?: MyCard[K] };
         "my-label": Omit<MyLabel, keyof MyLabelAttributes> & { [K in keyof MyLabel & keyof MyLabelAttributes]?: MyLabel[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `attr:${K}`]?: MyLabelAttributes[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `prop:${K}`]?: MyLabel[K] };
@@ -257,6 +294,11 @@ declare module "@stencil/core" {
              * Used to test that lifecycle hooks are called and errors propagate correctly.
              */
             "lifecycle-throw": LocalJSX.IntrinsicElements["lifecycle-throw"] & JSXBase.HTMLAttributes<HTMLLifecycleThrowElement>;
+            /**
+             * A labelled badge that extends FormattedBase for its text formatting.
+             * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+             */
+            "my-badge": LocalJSX.IntrinsicElements["my-badge"] & JSXBase.HTMLAttributes<HTMLMyBadgeElement>;
             /**
              * A simple button component for testing
              */

--- a/test-project/src/components/my-button/__snapshots__/snapshot-jsdom.spec.tsx.snap
+++ b/test-project/src/components/my-button/__snapshots__/snapshot-jsdom.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`my-button - snapshot tests (jsdom) > should match snapshot for card wit
   <p>
     Card content
   </p>
-  <my-button slot="footer" class="hydrated">
+  <my-button class="hydrated" slot="footer">
     <mock:shadow-root>
       <button class="button button--primary button--medium" type="button">
         <slot></slot>

--- a/test-project/src/components/my-button/__snapshots__/snapshot.spec.tsx.snap
+++ b/test-project/src/components/my-button/__snapshots__/snapshot.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`my-button - snapshot tests > should match snapshot for card with nested
   <p>
     Card content
   </p>
-  <my-button slot="footer" class="hydrated">
+  <my-button class="hydrated" slot="footer">
     <mock:shadow-root>
       <button class="button button--primary button--medium" type="button">
         <slot></slot>

--- a/test-project/src/components/non-shadow/__snapshots__/non-shadow-jsdom.spec.tsx.snap
+++ b/test-project/src/components/non-shadow/__snapshots__/non-shadow-jsdom.spec.tsx.snap
@@ -4,18 +4,18 @@ exports[`non-shadow-component serialization > nested components > should seriali
 <non-shadow-component class="sc-non-shadow-component-h hydrated">
   <div class="wrapper sc-non-shadow-component">
     <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-      <slot-fb name="header" class="sc-non-shadow-component" hidden>
+      <slot-fb class="sc-non-shadow-component" hidden name="header">
         Default Header
       </slot-fb>
-      <non-shadow-component slot="header" class="sc-non-shadow-component-h hydrated">
+      <non-shadow-component class="sc-non-shadow-component-h hydrated" slot="header">
         <div class="wrapper sc-non-shadow-component">
           <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-            <slot-fb name="header" class="sc-non-shadow-component">
+            <slot-fb class="sc-non-shadow-component" name="header">
               Default Header
             </slot-fb>
           </div>
           <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-            <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
+            <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
             <slot-fb class="sc-non-shadow-component" hidden>
               Default Content
             </slot-fb>
@@ -24,7 +24,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
             </span>
           </div>
           <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-            <slot-fb name="footer" class="sc-non-shadow-component">
+            <slot-fb class="sc-non-shadow-component" name="footer">
               Default Footer
             </slot-fb>
           </div>
@@ -32,7 +32,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
       </non-shadow-component>
     </div>
     <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-      <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
+      <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
       <slot-fb class="sc-non-shadow-component" hidden>
         Default Content
       </slot-fb>
@@ -41,7 +41,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
       </p>
     </div>
     <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-      <slot-fb name="footer" class="sc-non-shadow-component">
+      <slot-fb class="sc-non-shadow-component" name="footer">
         Default Footer
       </slot-fb>
     </div>

--- a/test-project/src/components/non-shadow/non-shadow-jsdom.spec.tsx
+++ b/test-project/src/components/non-shadow/non-shadow-jsdom.spec.tsx
@@ -135,12 +135,12 @@ describe('non-shadow-component serialization', () => {
           <non-shadow-component class="sc-non-shadow-component-h hydrated">
             <div class="wrapper sc-non-shadow-component">
               <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-                <slot-fb name="header" class="sc-non-shadow-component">
+                <slot-fb class="sc-non-shadow-component" name="header">
                   Default Header
                 </slot-fb>
               </div>
               <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-                <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
+                <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
                 <slot-fb class="sc-non-shadow-component" hidden>
                   Default Content
                 </slot-fb>
@@ -149,7 +149,7 @@ describe('non-shadow-component serialization', () => {
                 </span>
               </div>
               <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-                <slot-fb name="footer" class="sc-non-shadow-component">
+                <slot-fb class="sc-non-shadow-component" name="footer">
                   Default Footer
                 </slot-fb>
               </div>


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`pnpm build`) was run locally and passed
- [x] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [x] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Attribute order is non-deterministic 

Issue URL:

https://github.com/stenciljs/vitest/issues/47

## What is the new behavior?

Attributes are now ordered alphabetically

- Closes https://github.com/stenciljs/vitest/issues/47

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Users will have to run `--update` to update any snapshots 
