### PR TITLE
fix: revert attribute sorting

### DIFF
--- a/src/testing/html-serializer.ts
+++ b/src/testing/html-serializer.ts
@@ -102,15 +102,11 @@ function serializeElementWithShadow(
   // Build opening tag with attributes
   let html = `<${tagName}`;
 
-  // Add attributes sorted alphabetically for deterministic output across dev/prod builds
+  // Add attributes
   if (elem.attributes) {
-    const attrs = Array.from(elem.attributes).sort((a, b) => {
-      const nameA = a.prefix && a.localName ? `${a.prefix}:${a.localName}` : a.name;
-      const nameB = b.prefix && b.localName ? `${b.prefix}:${b.localName}` : b.name;
-      return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
-    });
+    for (let i = 0; i < elem.attributes.length; i++) {
+      const attr = elem.attributes[i];
 
-    for (const attr of attrs) {
       // Handle namespaced attributes (e.g., xlink:href)
       // Use prefix + localName if available, otherwise fall back to name
       let attrName = attr.name;
@@ -262,40 +258,6 @@ export function prettifyHtml(html: string): string {
   }
 
   return lines.join('\n');
-}
-
-/**
- * Sort attributes alphabetically within every opening HTML tag in a string.
- * Used to normalise expected HTML strings before comparison so that attribute
- * order written by hand in tests does not have to match the order produced by
- * the runtime (which can differ between dev and prod Stencil builds).
- *
- * Handles double-quoted attribute values and bare boolean attributes.
- * Does NOT touch closing tags, self-closing tags, or text content.
- */
-export function sortAttributesInHtml(html: string): string {
-  // Match opening tags: capture tag name and the rest of the attribute string
-  return html.replace(/<([a-zA-Z][a-zA-Z0-9:._-]*)((?:\s[^>]*)?)>/g, (_match, tagName: string, attrStr: string) => {
-    if (!attrStr.trim()) {
-      return `<${tagName}>`;
-    }
-
-    // Parse individual attributes (boolean attrs and attr="value" attrs)
-    const attrPattern = /\s+([^\s=>"/]+)(?:="([^"]*?)")?/g;
-    const attrs: Array<{ name: string; value: string | null }> = [];
-    let m: RegExpExecArray | null;
-    while ((m = attrPattern.exec(attrStr)) !== null) {
-      attrs.push({ name: m[1], value: m[2] !== undefined ? m[2] : null });
-    }
-
-    attrs.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-
-    const sortedAttrStr = attrs
-      .map(({ name, value }) => (value === null ? ` ${name}` : ` ${name}="${value}"`))
-      .join('');
-
-    return `<${tagName}${sortedAttrStr}>`;
-  });
 }
 
 /**

--- a/src/testing/matchers.ts
+++ b/src/testing/matchers.ts
@@ -5,7 +5,7 @@
  */
 
 import { expect } from 'vitest';
-import { serializeHtml, normalizeHtml, prettifyHtml, sortAttributesInHtml } from './html-serializer.js';
+import { serializeHtml, normalizeHtml, prettifyHtml } from './html-serializer.js';
 import type { EventSpy } from '../types.js';
 
 /**
@@ -441,9 +441,8 @@ function toEqualHtml(
     const expectedFragment = parseHtmlFragment(expected.trim());
     expectedHtml = serializeHtml(expectedFragment, { serializeShadowRoot: true, pretty: false });
   } else {
-    // For element comparisons, sort attributes so hand-written expected HTML is
-    // order-independent (dev vs prod builds can reflect props in different orders)
-    expectedHtml = sortAttributesInHtml(expected.trim());
+    // For element comparisons, just normalize to preserve <mock:shadow-root> tags
+    expectedHtml = expected.trim();
   }
 
   expectedHtml = normalizeHtml(expectedHtml);
@@ -501,9 +500,8 @@ function toEqualLightHtml(
     const expectedFragment = parseHtmlFragment(expected.trim());
     expectedHtml = serializeHtml(expectedFragment, { serializeShadowRoot: false, pretty: false });
   } else {
-    // For element comparisons, sort attributes so hand-written expected HTML is
-    // order-independent (dev vs prod builds can reflect props in different orders)
-    expectedHtml = sortAttributesInHtml(expected.trim());
+    // For element comparisons, just normalize to preserve <mock:shadow-root> tags
+    expectedHtml = expected.trim();
   }
 
   expectedHtml = normalizeHtml(expectedHtml);

--- a/test-project/src/components.d.ts
+++ b/test-project/src/components.d.ts
@@ -17,6 +17,17 @@ export namespace Components {
         "label": string;
     }
     /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface MyBadge {
+        /**
+          * The badge label — passed through this.format() before rendering
+          * @default ''
+         */
+        "label": string;
+    }
+    /**
      * A simple button component for testing
      */
     interface MyButton {
@@ -90,6 +101,16 @@ declare global {
         prototype: HTMLLifecycleThrowElement;
         new (): HTMLLifecycleThrowElement;
     };
+    /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface HTMLMyBadgeElement extends Components.MyBadge, HTMLStencilElement {
+    }
+    var HTMLMyBadgeElement: {
+        prototype: HTMLMyBadgeElement;
+        new (): HTMLMyBadgeElement;
+    };
     interface HTMLMyButtonElementEventMap {
         "buttonClick": MouseEvent;
     }
@@ -143,6 +164,7 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "lifecycle-throw": HTMLLifecycleThrowElement;
+        "my-badge": HTMLMyBadgeElement;
         "my-button": HTMLMyButtonElement;
         "my-card": HTMLMyCardElement;
         "my-label": HTMLMyLabelElement;
@@ -157,6 +179,17 @@ declare namespace LocalJSX {
     interface LifecycleThrow {
         /**
           * Required label prop - throws if not provided
+         */
+        "label"?: string;
+    }
+    /**
+     * A labelled badge that extends FormattedBase for its text formatting.
+     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+     */
+    interface MyBadge {
+        /**
+          * The badge label — passed through this.format() before rendering
+          * @default ''
          */
         "label"?: string;
     }
@@ -226,6 +259,9 @@ declare namespace LocalJSX {
     interface LifecycleThrowAttributes {
         "label": string;
     }
+    interface MyBadgeAttributes {
+        "label": string;
+    }
     interface MyButtonAttributes {
         "variant": 'primary' | 'secondary' | 'danger';
         "disabled": boolean;
@@ -242,6 +278,7 @@ declare namespace LocalJSX {
 
     interface IntrinsicElements {
         "lifecycle-throw": Omit<LifecycleThrow, keyof LifecycleThrowAttributes> & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes]?: LifecycleThrow[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `attr:${K}`]?: LifecycleThrowAttributes[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `prop:${K}`]?: LifecycleThrow[K] };
+        "my-badge": Omit<MyBadge, keyof MyBadgeAttributes> & { [K in keyof MyBadge & keyof MyBadgeAttributes]?: MyBadge[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `attr:${K}`]?: MyBadgeAttributes[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `prop:${K}`]?: MyBadge[K] };
         "my-button": Omit<MyButton, keyof MyButtonAttributes> & { [K in keyof MyButton & keyof MyButtonAttributes]?: MyButton[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `attr:${K}`]?: MyButtonAttributes[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `prop:${K}`]?: MyButton[K] };
         "my-card": Omit<MyCard, keyof MyCardAttributes> & { [K in keyof MyCard & keyof MyCardAttributes]?: MyCard[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `attr:${K}`]?: MyCardAttributes[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `prop:${K}`]?: MyCard[K] };
         "my-label": Omit<MyLabel, keyof MyLabelAttributes> & { [K in keyof MyLabel & keyof MyLabelAttributes]?: MyLabel[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `attr:${K}`]?: MyLabelAttributes[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `prop:${K}`]?: MyLabel[K] };
@@ -257,6 +294,11 @@ declare module "@stencil/core" {
              * Used to test that lifecycle hooks are called and errors propagate correctly.
              */
             "lifecycle-throw": LocalJSX.IntrinsicElements["lifecycle-throw"] & JSXBase.HTMLAttributes<HTMLLifecycleThrowElement>;
+            /**
+             * A labelled badge that extends FormattedBase for its text formatting.
+             * Demonstrates that vi.mock() intercepts imports used in inherited methods.
+             */
+            "my-badge": LocalJSX.IntrinsicElements["my-badge"] & JSXBase.HTMLAttributes<HTMLMyBadgeElement>;
             /**
              * A simple button component for testing
              */

--- a/test-project/src/components.d.ts
+++ b/test-project/src/components.d.ts
@@ -17,17 +17,6 @@ export namespace Components {
         "label": string;
     }
     /**
-     * A labelled badge that extends FormattedBase for its text formatting.
-     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
-     */
-    interface MyBadge {
-        /**
-          * The badge label — passed through this.format() before rendering
-          * @default ''
-         */
-        "label": string;
-    }
-    /**
      * A simple button component for testing
      */
     interface MyButton {
@@ -101,16 +90,6 @@ declare global {
         prototype: HTMLLifecycleThrowElement;
         new (): HTMLLifecycleThrowElement;
     };
-    /**
-     * A labelled badge that extends FormattedBase for its text formatting.
-     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
-     */
-    interface HTMLMyBadgeElement extends Components.MyBadge, HTMLStencilElement {
-    }
-    var HTMLMyBadgeElement: {
-        prototype: HTMLMyBadgeElement;
-        new (): HTMLMyBadgeElement;
-    };
     interface HTMLMyButtonElementEventMap {
         "buttonClick": MouseEvent;
     }
@@ -164,7 +143,6 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "lifecycle-throw": HTMLLifecycleThrowElement;
-        "my-badge": HTMLMyBadgeElement;
         "my-button": HTMLMyButtonElement;
         "my-card": HTMLMyCardElement;
         "my-label": HTMLMyLabelElement;
@@ -179,17 +157,6 @@ declare namespace LocalJSX {
     interface LifecycleThrow {
         /**
           * Required label prop - throws if not provided
-         */
-        "label"?: string;
-    }
-    /**
-     * A labelled badge that extends FormattedBase for its text formatting.
-     * Demonstrates that vi.mock() intercepts imports used in inherited methods.
-     */
-    interface MyBadge {
-        /**
-          * The badge label — passed through this.format() before rendering
-          * @default ''
          */
         "label"?: string;
     }
@@ -259,9 +226,6 @@ declare namespace LocalJSX {
     interface LifecycleThrowAttributes {
         "label": string;
     }
-    interface MyBadgeAttributes {
-        "label": string;
-    }
     interface MyButtonAttributes {
         "variant": 'primary' | 'secondary' | 'danger';
         "disabled": boolean;
@@ -278,7 +242,6 @@ declare namespace LocalJSX {
 
     interface IntrinsicElements {
         "lifecycle-throw": Omit<LifecycleThrow, keyof LifecycleThrowAttributes> & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes]?: LifecycleThrow[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `attr:${K}`]?: LifecycleThrowAttributes[K] } & { [K in keyof LifecycleThrow & keyof LifecycleThrowAttributes as `prop:${K}`]?: LifecycleThrow[K] };
-        "my-badge": Omit<MyBadge, keyof MyBadgeAttributes> & { [K in keyof MyBadge & keyof MyBadgeAttributes]?: MyBadge[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `attr:${K}`]?: MyBadgeAttributes[K] } & { [K in keyof MyBadge & keyof MyBadgeAttributes as `prop:${K}`]?: MyBadge[K] };
         "my-button": Omit<MyButton, keyof MyButtonAttributes> & { [K in keyof MyButton & keyof MyButtonAttributes]?: MyButton[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `attr:${K}`]?: MyButtonAttributes[K] } & { [K in keyof MyButton & keyof MyButtonAttributes as `prop:${K}`]?: MyButton[K] };
         "my-card": Omit<MyCard, keyof MyCardAttributes> & { [K in keyof MyCard & keyof MyCardAttributes]?: MyCard[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `attr:${K}`]?: MyCardAttributes[K] } & { [K in keyof MyCard & keyof MyCardAttributes as `prop:${K}`]?: MyCard[K] };
         "my-label": Omit<MyLabel, keyof MyLabelAttributes> & { [K in keyof MyLabel & keyof MyLabelAttributes]?: MyLabel[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `attr:${K}`]?: MyLabelAttributes[K] } & { [K in keyof MyLabel & keyof MyLabelAttributes as `prop:${K}`]?: MyLabel[K] };
@@ -294,11 +257,6 @@ declare module "@stencil/core" {
              * Used to test that lifecycle hooks are called and errors propagate correctly.
              */
             "lifecycle-throw": LocalJSX.IntrinsicElements["lifecycle-throw"] & JSXBase.HTMLAttributes<HTMLLifecycleThrowElement>;
-            /**
-             * A labelled badge that extends FormattedBase for its text formatting.
-             * Demonstrates that vi.mock() intercepts imports used in inherited methods.
-             */
-            "my-badge": LocalJSX.IntrinsicElements["my-badge"] & JSXBase.HTMLAttributes<HTMLMyBadgeElement>;
             /**
              * A simple button component for testing
              */

--- a/test-project/src/components/my-button/__snapshots__/snapshot-jsdom.spec.tsx.snap
+++ b/test-project/src/components/my-button/__snapshots__/snapshot-jsdom.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`my-button - snapshot tests (jsdom) > should match snapshot for card wit
   <p>
     Card content
   </p>
-  <my-button class="hydrated" slot="footer">
+  <my-button slot="footer" class="hydrated">
     <mock:shadow-root>
       <button class="button button--primary button--medium" type="button">
         <slot></slot>

--- a/test-project/src/components/my-button/__snapshots__/snapshot.spec.tsx.snap
+++ b/test-project/src/components/my-button/__snapshots__/snapshot.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`my-button - snapshot tests > should match snapshot for card with nested
   <p>
     Card content
   </p>
-  <my-button class="hydrated" slot="footer">
+  <my-button slot="footer" class="hydrated">
     <mock:shadow-root>
       <button class="button button--primary button--medium" type="button">
         <slot></slot>

--- a/test-project/src/components/my-button/matchers.spec.tsx
+++ b/test-project/src/components/my-button/matchers.spec.tsx
@@ -203,4 +203,60 @@ describe('my-button - custom matchers', () => {
       }).toThrow();
     });
   });
+
+  describe('JSON-valued attributes (regression for #51)', () => {
+    // Regression: a previous attempt at attribute sorting (sortAttributesInHtml)
+    // used a regex that truncated values containing double-quotes (e.g. JSON objects)
+    // and stripped values from single-quoted attributes entirely.
+    // The fix is to not sort — users write attributes in the order the serializer
+    // produces them (alphabetical), same as every other testing library.
+
+    it('toEqualLightHtml: attribute with JSON value (single-quoted in expected string)', async () => {
+      const { root, waitForChanges } = await render(<my-button>Test</my-button>);
+      await waitForChanges();
+
+      root.setAttribute('class', 'hydrated');
+      root.setAttribute('name', 'TEST');
+      root.setAttribute('tracking-context', '{"page":"home"}');
+
+      // Attributes written in alphabetical order (as the serializer produces them).
+      // Single quotes wrap the expected string so the JSON value's double-quotes are literal.
+      expect(root).toEqualLightHtml(
+        `<my-button class="hydrated" name="TEST" tracking-context="{"page":"home"}">
+          Test
+        </my-button>`,
+      );
+    });
+
+    it('toEqualLightHtml: fails when JSON value does not match', async () => {
+      const { root, waitForChanges } = await render(<my-button>Test</my-button>);
+      await waitForChanges();
+
+      root.setAttribute('tracking-context', '{"page":"home"}');
+
+      expect(() => {
+        expect(root).toEqualLightHtml(
+          `<my-button class="hydrated" tracking-context='{"page":"other"}'>Test</my-button>`,
+        );
+      }).toThrow();
+    });
+
+    it('toEqualHtml: JSON attribute value survives shadow-DOM comparison', async () => {
+      const { root, waitForChanges } = await render(<my-button>Test</my-button>);
+      await waitForChanges();
+
+      root.setAttribute('tracking-context', '{"page":"home","section":"nav"}');
+
+      expect(root).toEqualHtml(`
+        <my-button class="hydrated" tracking-context="{"page":"home","section":"nav"}">
+          <mock:shadow-root>
+            <button class="button button--primary button--medium" type="button">
+              <slot></slot>
+            </button>
+          </mock:shadow-root>
+          Test
+        </my-button>
+      `);
+    });
+  });
 });

--- a/test-project/src/components/non-shadow/__snapshots__/non-shadow-jsdom.spec.tsx.snap
+++ b/test-project/src/components/non-shadow/__snapshots__/non-shadow-jsdom.spec.tsx.snap
@@ -4,18 +4,18 @@ exports[`non-shadow-component serialization > nested components > should seriali
 <non-shadow-component class="sc-non-shadow-component-h hydrated">
   <div class="wrapper sc-non-shadow-component">
     <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-      <slot-fb class="sc-non-shadow-component" hidden name="header">
+      <slot-fb name="header" class="sc-non-shadow-component" hidden>
         Default Header
       </slot-fb>
-      <non-shadow-component class="sc-non-shadow-component-h hydrated" slot="header">
+      <non-shadow-component slot="header" class="sc-non-shadow-component-h hydrated">
         <div class="wrapper sc-non-shadow-component">
           <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-            <slot-fb class="sc-non-shadow-component" name="header">
+            <slot-fb name="header" class="sc-non-shadow-component">
               Default Header
             </slot-fb>
           </div>
           <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-            <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
+            <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
             <slot-fb class="sc-non-shadow-component" hidden>
               Default Content
             </slot-fb>
@@ -24,7 +24,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
             </span>
           </div>
           <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-            <slot-fb class="sc-non-shadow-component" name="footer">
+            <slot-fb name="footer" class="sc-non-shadow-component">
               Default Footer
             </slot-fb>
           </div>
@@ -32,7 +32,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
       </non-shadow-component>
     </div>
     <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-      <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
+      <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
       <slot-fb class="sc-non-shadow-component" hidden>
         Default Content
       </slot-fb>
@@ -41,7 +41,7 @@ exports[`non-shadow-component serialization > nested components > should seriali
       </p>
     </div>
     <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-      <slot-fb class="sc-non-shadow-component" name="footer">
+      <slot-fb name="footer" class="sc-non-shadow-component">
         Default Footer
       </slot-fb>
     </div>

--- a/test-project/src/components/non-shadow/non-shadow-jsdom.spec.tsx
+++ b/test-project/src/components/non-shadow/non-shadow-jsdom.spec.tsx
@@ -135,12 +135,12 @@ describe('non-shadow-component serialization', () => {
           <non-shadow-component class="sc-non-shadow-component-h hydrated">
             <div class="wrapper sc-non-shadow-component">
               <div class="header sc-non-shadow-component sc-non-shadow-component-s">
-                <slot-fb class="sc-non-shadow-component" name="header">
+                <slot-fb name="header" class="sc-non-shadow-component">
                   Default Header
                 </slot-fb>
               </div>
               <div class="content sc-non-shadow-component sc-non-shadow-component-s">
-                <img alt="Placeholder Image" class="sc-non-shadow-component" src="https://via.placeholder.com/150">
+                <img src="https://via.placeholder.com/150" alt="Placeholder Image" class="sc-non-shadow-component">
                 <slot-fb class="sc-non-shadow-component" hidden>
                   Default Content
                 </slot-fb>
@@ -149,7 +149,7 @@ describe('non-shadow-component serialization', () => {
                 </span>
               </div>
               <div class="footer sc-non-shadow-component sc-non-shadow-component-s">
-                <slot-fb class="sc-non-shadow-component" name="footer">
+                <slot-fb name="footer" class="sc-non-shadow-component">
                   Default Footer
                 </slot-fb>
               </div>


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Sorting attributes is too error prone and complex. 

Issue URL:

## What is the new behavior?

Have removed attribute soreing.
The issue reported in #47 is easily remedied - users should just test with the same options.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
