### PR TITLE
fix(plugin): state decorator initial values

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -111,7 +111,7 @@ export function stencilVitestPlugin(opts: { css?: boolean } = {}): Plugin {
           sourceMap: false,
           style: opts.css ? 'static' : null,
           styleImportData: opts.css ? 'queryparams' : null,
-          target: 'es2022',
+          target: 'es2017',
           // Don't rewrite import paths — let Vite handle resolution via aliases
           transformAliasedImportPaths: false,
         });

--- a/test-project/src/components/my-label/my-label.plugin.spec.tsx
+++ b/test-project/src/components/my-label/my-label.plugin.spec.tsx
@@ -36,7 +36,7 @@ describe('my-label — module mocking via stencilVitestPlugin', () => {
 
     const { root } = await render(<my-label value="hello" />);
     const span = root.shadowRoot!.querySelector('span');
-    expect(span?.textContent).toBe('Hello');
+    expect(span?.textContent).toBe('Hello state: value');
   });
 
   it('renders using the mocked capitalize', async () => {
@@ -45,7 +45,7 @@ describe('my-label — module mocking via stencilVitestPlugin', () => {
     const { root } = await render(<my-label value="hello" />);
     const span = root.shadowRoot!.querySelector('span');
 
-    expect(span?.textContent).toBe('[mocked:hello]');
+    expect(span?.textContent).toBe('[mocked:hello] state: value');
     expect(capitalize).toHaveBeenCalledWith('hello');
   });
 
@@ -53,12 +53,12 @@ describe('my-label — module mocking via stencilVitestPlugin', () => {
     vi.mocked(capitalize).mockImplementation((s) => `UPPER:${s.toUpperCase()}`);
 
     const { root, setProps, waitForChanges } = await render(<my-label value="world" />);
-    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:WORLD');
+    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:WORLD state: value');
 
     await setProps({ value: 'changed' });
     await waitForChanges();
 
-    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:CHANGED');
+    expect(root.shadowRoot!.querySelector('span')?.textContent).toBe('UPPER:CHANGED state: value');
     expect(capitalize).toHaveBeenCalledTimes(2);
   });
 });

--- a/test-project/src/components/my-label/my-label.tsx
+++ b/test-project/src/components/my-label/my-label.tsx
@@ -14,8 +14,8 @@ export class MyLabel {
   /** Raw text to display — run through `capitalize()` before rendering */
   @Prop() value: string = '';
 
-   @State() state = {
-    property: 'value'
+  @State() state = {
+    property: 'value',
   };
 
   componentDidLoad(): void {
@@ -23,6 +23,10 @@ export class MyLabel {
   }
 
   render() {
-    return <span class="label">{capitalize(this.value)} state: {this.state.property}</span>;
+    return (
+      <span class="label">
+        {capitalize(this.value)} state: {this.state.property}
+      </span>
+    );
   }
 }

--- a/test-project/src/components/my-label/my-label.tsx
+++ b/test-project/src/components/my-label/my-label.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Prop, State, h } from '@stencil/core';
 import { capitalize } from '../../utils/index.js';
 
 /**
@@ -14,11 +14,15 @@ export class MyLabel {
   /** Raw text to display — run through `capitalize()` before rendering */
   @Prop() value: string = '';
 
+   @State() state = {
+    property: 'value'
+  };
+
   componentDidLoad(): void {
     window.dispatchEvent(new Event('custom-event'));
   }
 
   render() {
-    return <span class="label">{capitalize(this.value)}</span>;
+    return <span class="label">{capitalize(this.value)} state: {this.state.property}</span>;
   }
 }


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Build (`pnpm build`) was run locally and passed
- [ ] Tests (`pnpm test:unit` and `pnpm test:e2e`) were run locally and passed
- [ ] Linting (`pnpm lint`) was run locally and passed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (please describe):

## What is the current behavior?

Issue URL:

## What is the new behavior?

Closes #65

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
